### PR TITLE
Update XLD from 5.1.1 to 5.1.3

### DIFF
--- a/xldeploy/Dockerfile
+++ b/xldeploy/Dockerfile
@@ -2,7 +2,7 @@ FROM debian
 
 MAINTAINER Fai Fung <ffung@xebia.com>
 
-ENV version 5.1.1
+ENV version 5.1.3
 RUN apt-get update
 RUN apt-get install -y openjdk-7-jre-headless unzip wget --no-install-recommends
 


### PR DESCRIPTION
Building the Docker image with 5.1.1 leads to an HTTP 500 error while downloading the XLD trial.
